### PR TITLE
fix: collapse mobile navbar after clicking link

### DIFF
--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -37,7 +37,12 @@ const Navbar = ({ onClose, ...rest }: NavbarProps): React.ReactElement => {
         <CloseButton display={{ base: 'flex', md: 'none' }} onClick={onClose} />
       </Flex>
       {LinkItems.map((link) => (
-        <NavItem key={link.name} icon={link.icon} to={link.to}>
+        <NavItem
+          key={link.name}
+          icon={link.icon}
+          to={link.to}
+          onClick={onClose}
+        >
           {link.name}
         </NavItem>
       ))}
@@ -47,12 +52,13 @@ const Navbar = ({ onClose, ...rest }: NavbarProps): React.ReactElement => {
 
 const NavItem = ({
   to,
+  onClick,
   icon,
   children,
   ...rest
 }: NavItemProps): React.ReactElement => {
   return (
-    <RouteLink to={to}>
+    <RouteLink to={to} onClick={onClick}>
       <Flex
         align="center"
         p="4"

--- a/src/components/Navbar/types.d.ts
+++ b/src/components/Navbar/types.d.ts
@@ -15,6 +15,7 @@ export interface NavbarProps extends BoxProps {
 }
 
 export interface NavItemProps extends FlexProps {
+  onClick: () => void;
   icon: IconType;
   children: ReactText;
   to: string;

--- a/src/layouts/NavbarLayout/index.tsx
+++ b/src/layouts/NavbarLayout/index.tsx
@@ -5,7 +5,8 @@ import {
   useColorModeValue,
   Drawer,
   DrawerContent,
-  useDisclosure
+  useDisclosure,
+  DrawerOverlay
 } from '@chakra-ui/react';
 
 import Navbar from '../../components/Navbar';
@@ -29,6 +30,7 @@ const NavbarLayout = ({
         onOverlayClick={onClose}
         size="full"
       >
+        <DrawerOverlay />
         <DrawerContent>
           <Navbar onClose={onClose} />
         </DrawerContent>


### PR DESCRIPTION
## Status:

:construction: In development

## Description
The current mobile navbar requires the user to click the close button after clicking a page. Now, the navbar collapses automatically after the page is clicked. I also tried animating the close, but it seems a bit too fast. I haven't found anything that allows you to adjust the transition speed of a `Drawer`. 

## Screenshots
https://user-images.githubusercontent.com/34558138/214871137-79bcabd1-afd9-46ea-9d06-d664784d040a.mp4