### PR TITLE
fix: listen on 127.0.0.1

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,11 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-   server: {
-    port: 8080,
-  },
-})
+  server: {
+    host: '127.0.0.1',
+    port: 8080
+  }
+});


### PR DESCRIPTION
## Status:

:rocket: Ready

## Description
The Vite server listens on `localhost` by default, but the server needs to listen on `127.0.0.1` to match the API's origin. A mismatch will cause the same-origin policy to fail, so cookies will not be shared.
