### PR TITLE
show point code for officers

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -3,8 +3,8 @@ import axios from 'axios';
 const instance = axios.create({
   baseURL: import.meta.env.VITE_BASE_URL
     ? import.meta.env.VITE_BASE_URL
-    : // : 'http://127.0.0.1:3000',
-      'https://points-api.illinoiswcs.org',
+    // : 'http://127.0.0.1:3000',
+    : 'https://points-api.illinoiswcs.org',
   withCredentials: true
 });
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -3,7 +3,8 @@ import axios from 'axios';
 const instance = axios.create({
   baseURL: import.meta.env.VITE_BASE_URL
     ? import.meta.env.VITE_BASE_URL
-    : 'https://points-api.illinoiswcs.org',
+    : // : 'http://127.0.0.1:3000',
+      'https://points-api.illinoiswcs.org',
   withCredentials: true
 });
 

--- a/src/pages/Events/index.tsx
+++ b/src/pages/Events/index.tsx
@@ -70,6 +70,9 @@ const Events = (): React.ReactElement => {
                 {event.name}
               </Text>
               <Text className="muted">{getEventDate(event)}</Text>
+              <Text className="muted" fontSize="sm">
+                {event.key ?? ' '}
+              </Text>
             </Box>
           ))}
         </Stack>


### PR DESCRIPTION
## Status:

<!--
:construction: In development
:no_entry_sign: Do not merge
-->
 :rocket:

## Description

Showed the point code on the events page for only officers. Else, show nothing.

Closes #21 

## Screenshots

<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->

<img width="1260" alt="image" src="https://github.com/IllinoisWCS/points-frontend/assets/57074850/96b41398-d0fb-4831-bc97-4d941ab9f24a">

