### PR TITLE
Render QR code relative to window width

### DIFF
--- a/src/pages/Events/QRCodeModal/index.tsx
+++ b/src/pages/Events/QRCodeModal/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   Modal,
   ModalCloseButton,
@@ -24,6 +24,27 @@ const QRCodeModal = (props: QRCodeModalProps): React.ReactElement => {
   const clearAndToggle = (): void => {
     toggleModal();
   };
+
+  const useWindowDimensions = (): { /* height: number; */ width: number; } => {
+    const [dimensions, setDimensions] = useState({
+      width: window.innerWidth
+      // height: window.innerHeight,
+    });
+
+    useEffect(() => {
+      const handleResize = (): void => {
+        setDimensions({
+          width: window.innerWidth /* height: window.innerHeight */
+        });
+      };
+      window.addEventListener('resize', handleResize);
+      return () => { window.removeEventListener('resize', handleResize); };
+    }, []);
+
+    return dimensions;
+  };
+
+  const { /* height, */ width } = useWindowDimensions();
 
   return (
     <Modal isOpen={open} onClose={clearAndToggle} isCentered>
@@ -55,7 +76,7 @@ const QRCodeModal = (props: QRCodeModalProps): React.ReactElement => {
             <Box>
               <EventQRCode
                 eventKey={event?.key}
-                size={320}
+                size={width < 448 ? width - 128 : 320}
                 color={isToggled ? '#d4696a' : '#000000'}
               />
             </Box>


### PR DESCRIPTION
## Status:

<!--
:rocket: Ready
:construction: In development
:no_entry_sign: Do not merge
-->

## Description
Fixes QR code alignment and renders relative to screen width.
<!--
A few sentences describing the overall goals of the pull request's commits. If applicable, link the PR to the corresponding issue below by filling out the number.
-->

Closes #64 

## Screenshots

Before
![Screenshot 2025-04-13 at 13.46.29.png](attachment:414aef0b-edaa-41ca-b78f-7fcd80dc1da8:Screenshot_2025-04-13_at_13.46.29.png)

After
![Screenshot 2025-04-13 at 13.46.57.png](attachment:3acd4788-d3db-45ff-8bfc-f8b1bf1be5fb:Screenshot_2025-04-13_at_13.46.57.png)
<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
